### PR TITLE
Fix: Navbar splitting into two rows on medium screen sizes  #175

### DIFF
--- a/src/components/Layout/Navbar/index.tsx
+++ b/src/components/Layout/Navbar/index.tsx
@@ -78,7 +78,7 @@ const Navbar: React.FC = () => {
   return (
     <div className="fixed top-0 start-0 flex justify-between w-full z-20">
       <nav className="bg-white border-gray-200 container mx-auto">
-        <div className="flex flex-wrap items-center justify-between p-4">
+        <div className="flex gap-1  flex-nowrap items-center justify-between p-4">
           <Link to="/">
             <img
               src="/scholarx-logo.png"
@@ -87,7 +87,7 @@ const Navbar: React.FC = () => {
             />
           </Link>
           <div className="flex items-center md:items-start">
-            <ul className="items-baseline hidden md:flex flex-col font-medium p-4 md:p-0 mt-4 border border-gray-100 rounded-lg bg-gray-50 md:space-x-8 rtl:space-x-reverse md:flex-row md:mt-0 md:border-0 md:bg-white">
+            <ul className="items-center hidden md:flex flex-col font-medium p-4 md:p-0 mt-4 border border-gray-100 rounded-lg bg-gray-50 md:space-x-2 text-nowrap rtl:space-x-reverse md:flex-row md:mt-0 md:border-0 md:bg-white">
               <li>
                 <Link
                   className="py-2 px-3 text-gray-900 rounded hover:bg-gray-100 cursor-pointer"


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix  #175

## Goals
The goal of this PR is to Fix Navigation bar splitting into two rows on medium screen sizes (eg-: iPad Air, iPad Mini)

## Approach
- Adjusted the tailwindcss styles to maintain a single-row layout for the navigation bar on medium screen sizes.
- Tested the changes on different screen sizes to ensure consistency and responsiveness.

## Screenshots
![Screenshot (107)](https://github.com/user-attachments/assets/0082b645-d4cc-47eb-b33a-d22e3d553c0e)



## Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Related PRs


## Test environment
- OS : Windows 11
- Browser : Google Chrome
