### PR TITLE
Refactor EditProfileForm component and useUserProfile hook

### DIFF
--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -2,7 +2,6 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { API_URL } from '../constants';
 import axios from 'axios';
 import { type Profile } from '../types';
-import { useEffect, useState } from 'react';
 
 const useProfile = () => {
   const queryClient = useQueryClient();

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { API_URL } from '../constants';
 import axios from 'axios';
 import { type Profile } from '../types';
+import { useEffect, useState } from 'react';
 
 const useProfile = () => {
   const queryClient = useQueryClient();

--- a/src/hooks/useUserProfile.ts
+++ b/src/hooks/useUserProfile.ts
@@ -1,0 +1,43 @@
+import { useState, useEffect } from 'react';
+import { type UserContextType } from '../contexts/UserContext';
+
+const useUserProfile = (user: UserContextType['user']) => {
+  const [profile, setProfile] = useState({
+    firstName: '',
+    lastName: '',
+    email: '',
+    profilePic: '',
+  });
+  const [image, setImage] = useState<File | null>(null);
+
+  useEffect(() => {
+    setProfile({
+      firstName: user?.first_name ?? '',
+      lastName: user?.last_name ?? '',
+      email: user?.primary_email ?? '',
+      profilePic: user?.image_url ?? '',
+    });
+  }, [user]);
+
+  const handleProfilePicChange = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    if (event.target.files != null) {
+      const file = event.target.files[0];
+      setImage(file);
+      setProfile({
+        ...profile,
+        profilePic: URL.createObjectURL(file),
+      });
+    }
+  };
+
+  return {
+    profile,
+    setProfile,
+    image,
+    handleProfilePicChange,
+  };
+};
+
+export default useUserProfile;


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #184 


## Goals
- Enable the submit button only when the user has made changes to the profile information or uploaded a new profile photo.
- Successfully allow users to update their details, including first name, last name, and profile photo.


## Approach
- The useUserProfile hook manages the state for the user's profile information and profile picture.
- It initializes the profile state with the user's current information and updates the state when the user changes any input field or uploads a new profile photo.
- The handleProfilePicChange function updates the profile picture state and creates a URL for the uploaded image.

## Screenshots
<!--- Attach screenshots or demo-gif of any UI changes -->

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Related PRs
<!--- List any other related PRs --> 

## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 
NodeJS - v20.15.0
FireFox - v129

## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
React Custom Hooks