### PR TITLE
Change the Breadcrumb names into one  line on mobile view

### DIFF
--- a/src/pages/MenteeProfile/MenteeProfile.component.tsx
+++ b/src/pages/MenteeProfile/MenteeProfile.component.tsx
@@ -13,8 +13,24 @@ const MenteeProfile: React.FC = () => {
 
   return (
     <>
-      <nav aria-label="Breadcrumb">
-        <ol className="flex items-center gap-1 text-xs sm:text-sm md:text-base text-gray-600">
+      <nav aria-label="Breadcrumb ">
+      <div className="flex items-center">
+        <button className="transform rotate-180 md:hidden">
+          <Link
+          to={`/mentors/${mentee?.mentor.uuid ?? ''}`}
+          className="block transition hover:text-gray-700 md:hidden ml-2">
+            <ChevronRightIcon />
+          </Link>
+        </button>
+        <Link
+          to={`/mentors/${mentee?.mentor.uuid ?? ''}`}
+          className="block transition hover:text-gray-700 md:hidden ml-2"
+        >
+          Back
+        </Link>
+      </div>
+
+        <ol className="flex items-center gap-1 text-xs sm:text-sm hidden md:flex text-gray-600">
           <li>
             <Link
               to="/mentors"

--- a/src/pages/MenteeProfile/MenteeProfile.component.tsx
+++ b/src/pages/MenteeProfile/MenteeProfile.component.tsx
@@ -14,21 +14,22 @@ const MenteeProfile: React.FC = () => {
   return (
     <>
       <nav aria-label="Breadcrumb ">
-      <div className="flex items-center">
-        <button className="transform rotate-180 md:hidden">
+        <div className="flex items-center">
+          <button className="transform rotate-180 md:hidden">
+            <Link
+              to={`/mentors/${mentee?.mentor.uuid ?? ''}`}
+              className="block transition hover:text-gray-700 md:hidden ml-2"
+            >
+              <ChevronRightIcon />
+            </Link>
+          </button>
           <Link
-          to={`/mentors/${mentee?.mentor.uuid ?? ''}`}
-          className="block transition hover:text-gray-700 md:hidden ml-2">
-            <ChevronRightIcon />
+            to={`/mentors/${mentee?.mentor.uuid ?? ''}`}
+            className="block transition hover:text-gray-700 md:hidden ml-2"
+          >
+            Back
           </Link>
-        </button>
-        <Link
-          to={`/mentors/${mentee?.mentor.uuid ?? ''}`}
-          className="block transition hover:text-gray-700 md:hidden ml-2"
-        >
-          Back
-        </Link>
-      </div>
+        </div>
 
         <ol className="flex items-center gap-1 text-xs sm:text-sm hidden md:flex text-gray-600">
           <li>

--- a/src/pages/MenteeProfile/MenteeProfile.component.tsx
+++ b/src/pages/MenteeProfile/MenteeProfile.component.tsx
@@ -14,7 +14,7 @@ const MenteeProfile: React.FC = () => {
   return (
     <>
       <nav aria-label="Breadcrumb">
-        <ol className="flex items-center gap-1 text-sm text-gray-600">
+        <ol className="flex items-center gap-1 text-xs sm:text-sm md:text-base text-gray-600">
           <li>
             <Link
               to="/mentors"

--- a/src/pages/MenteeProfile/MenteeProfile.component.tsx
+++ b/src/pages/MenteeProfile/MenteeProfile.component.tsx
@@ -14,10 +14,10 @@ const MenteeProfile: React.FC = () => {
   return (
     <>
       <nav aria-label="Breadcrumb ">
-        <div className="flex items-center">
+        <div className="flex items-center md:hidden">
           <Link
             to={`/mentors/${mentee?.mentor.uuid ?? ''}`}
-            className="flex items-center transition hover:text-gray-700 md:hidden"
+            className="flex items-center transition hover:text-gray-700"
           >
             <span className="transform rotate-180">
               <ChevronRightIcon />

--- a/src/pages/MenteeProfile/MenteeProfile.component.tsx
+++ b/src/pages/MenteeProfile/MenteeProfile.component.tsx
@@ -15,19 +15,14 @@ const MenteeProfile: React.FC = () => {
     <>
       <nav aria-label="Breadcrumb ">
         <div className="flex items-center">
-          <button className="transform rotate-180 md:hidden">
-            <Link
-              to={`/mentors/${mentee?.mentor.uuid ?? ''}`}
-              className="block transition hover:text-gray-700 md:hidden ml-2"
-            >
-              <ChevronRightIcon />
-            </Link>
-          </button>
           <Link
             to={`/mentors/${mentee?.mentor.uuid ?? ''}`}
-            className="block transition hover:text-gray-700 md:hidden ml-2"
+            className="flex items-center transition hover:text-gray-700 md:hidden"
           >
-            Back
+            <span className="transform rotate-180">
+              <ChevronRightIcon />
+            </span>
+            <span className="ml-2">Back</span>
           </Link>
         </div>
 


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #177 

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
- The breadcrumb should display all names on a single line

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->
- Change `text-sm`  to `text-xs sm:text-sm md:text-base` that the text size will be xs (extra small) on mobile screens, change to sm (small) on small screens (640px and above), and increase to base (normal size) on medium screens (768px and above).

## Screenshots
<!--- Attach screenshots or demo-gif of any UI changes -->
![image](https://github.com/user-attachments/assets/ac4f3233-18c8-4fe4-9ee1-00007d8f5acb)


##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Related PRs
<!--- List any other related PRs --> 

## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 

## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
