### PR TITLE
Fix #200 Hide Website Link on Mentor Profile When Not Provided

### DIFF
--- a/src/pages/MentorProfile/MentorProfile.component.tsx
+++ b/src/pages/MentorProfile/MentorProfile.component.tsx
@@ -195,8 +195,7 @@ const MentorProfile: React.FC = () => {
           <span className="w-0.5 h-24 bg-gray-300 md:block hidden"></span>
 
           {mentor?.application.linkedin && (
-            <a
-              href={mentor.application.linkedin}
+            <a href={mentor.application.linkedin}
               target="_blank"
               rel="noreferrer"
               className="text-blue-500 underline"
@@ -206,8 +205,7 @@ const MentorProfile: React.FC = () => {
           )}
 
           {mentor?.application.website && (
-            <a
-              href={mentor.application.website}
+            <a href={mentor.application.website}
               target="_blank"
               rel="noreferrer"
               className="text-blue-500 underline"

--- a/src/pages/MentorProfile/MentorProfile.component.tsx
+++ b/src/pages/MentorProfile/MentorProfile.component.tsx
@@ -193,22 +193,28 @@ const MentorProfile: React.FC = () => {
         </div>
         <div className="flex flex-row md:gap-9 md:m-5 gap-4 mt-4">
           <span className="w-0.5 h-24 bg-gray-300 md:block hidden"></span>
-          <a
-            href={mentor?.application.linkedin}
-            target="_blank"
-            rel="noreferrer"
-            className="text-blue-500 underline"
-          >
-            Linkedin
-          </a>
-          <a
-            href={mentor?.application.website}
-            target="_blank"
-            rel="noreferrer"
-            className="text-blue-500 underline"
-          >
-            Website
-          </a>
+
+          {mentor?.application.linkedin && (
+            <a
+              href={mentor.application.linkedin}
+              target="_blank"
+              rel="noreferrer"
+              className="text-blue-500 underline"
+            >
+              Linkedin
+            </a>
+          )}
+
+          {mentor?.application.website && (
+            <a
+              href={mentor.application.website}
+              target="_blank"
+              rel="noreferrer"
+              className="text-blue-500 underline"
+            >
+              Website
+            </a>
+          )}
         </div>
       </div>
       <div className="pb-4">


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix #200. The issue was that the website link was incorrectly appearing on the Mentor Profile even when no valid website URL was provided by the mentor. This caused confusion for users as the link would still show up and redirect to a non-existent page.

## Goals
- Remove the website link if the mentor has not provided a valid website URL.

## Approach
- I modified the logic in the MentorProfile component to check if the mentor has a valid website URL before rendering the website link.
No changes were made to other sections of the profile page.

### Screenshots
<img width="1437" alt="img SS" src="https://github.com/user-attachments/assets/a3bc8842-f022-4fd0-8eb9-c0184dd75de0">


## Checklist
- [ ] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation


## Test environment
- Browser: Chrome
