### PR TITLE
removed the comma after mentee application position

### DIFF
--- a/src/components/MenteeCard/index.tsx
+++ b/src/components/MenteeCard/index.tsx
@@ -39,7 +39,7 @@ const MenteeCard: React.FC<MenteeCardProps> = ({
           </p>
         ) : (
           <>
-            <p className="text-sm">{mentee.application.position}</p>,
+            <p className="text-sm">{mentee.application.position}</p>
             <p className="text-xs text-gray-500">
               {mentee.application.company}
             </p>


### PR DESCRIPTION
## Purpose
In the mentor profile, there is an issue with the display of mentee profiles who are currently working. Specifically, when the mentee's title and company name are shown, there is an extra comma appearing between the two. This comma is placed on a new line, which causes a misalignment in the profile display.
The purpose of this PR is to fix #232 

## Goals

remove the comma and alignment between the title and company name is adjusted

## Approach

The issue was within the HTML structure of the mentor profile, the p element where the position of the mentee is shown was followed by a comma before the company name.
To resolve the issue, I edited the HTML structure by removing the comma placed directly after the <p> element showing the mentee’s position.

## Screenshots


##  Checklist
- [ x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x ] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation

## Related PRs
<!--- List any other related PRs --> 

## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 

## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
