### PR TITLE
docs: Correct repository URL and fix indentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Frontend dashboard of the scholarX platform
 
 1. Clone your forked repository
    ```
-   git clone https://github.com/sef-global/scholarx-frontend.git
+   git clone https://github.com/YOUR_USERNAME/scholarx-frontend.git
    cd scholarx-frontend
    ```
 2. Install all the dependencies

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Scholarx-frontend
+
 Frontend dashboard of the scholarX platform
 
 ## Setup Development Environment
@@ -6,19 +7,20 @@ Frontend dashboard of the scholarX platform
 ### **Project setup walkthrough :- https://youtu.be/1STopJMM2nM**
 
 1. Clone your forked repository
-    ```
-    git clone https://github.com/USERNAME/scholarx-frontend
-    cd scholarx-frontend
-    ```
+   ```
+   git clone https://github.com/sef-global/scholarx-frontend.git
+   cd scholarx-frontend
+   ```
 2. Install all the dependencies
-    ```
-    npm install
-    ```
+   ```
+   npm install
+   ```
 
 - Start the server with
-    ```
-    npm run dev
-    ```
+
+  ```
+  npm run dev
+  ```
 
 - Visit your app at http://localhost:5173
 
@@ -28,11 +30,10 @@ The URL for the backend API is stored in an environment variable. To set this up
 
 - Copy the .env file:
 
-    ```
-    cp example.env .env
-    ```
+  ```
+  cp example.env .env
+  ```
 
 Replace the environment variables in the newly created .env file with your configuration.
-
 
 Please note that you should not commit this change to the repository. It's recommended to use environment variables for different environments.


### PR DESCRIPTION
## Changes Made  
- **Fixed incorrect repository link:**  
  Updated `https://github.com/USERNAME/scholarx-frontend` to the correct URL:  
  `https://github.com/sef-global/scholarx-frontend.git`.  
- **Adjusted indentation:**  
  Fixed misaligned code blocks for terminal commands to ensure Markdown renders correctly.  

## Checklist  
- [x] No secrets are committed.  
- [x] Documentation follows project guidelines.  

**Commit Summary:**  
- Fix broken `git clone` URL in README.  
- Correct indentation for code block consistency.  