### PR TITLE
Fix: Missing 'e' in banner under Navbar

### DIFF
--- a/src/components/Layout/Navbar/index.tsx
+++ b/src/components/Layout/Navbar/index.tsx
@@ -299,7 +299,7 @@ const Navbar: React.FC = () => {
         </div>
         <StickyBanner>
           <p className="flex items-center text-md font-normal text-gray-500">
-            Please not that we will not be processing new applications at this
+            Please note that we will not be processing new applications at this
             time.
           </p>
         </StickyBanner>


### PR DESCRIPTION
## Purpose

<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #<issue-number>

## Goals
Corrected a spelling error in the sticky banner displayed below the navigation bar on the ScholarX homepage. The letter "e" was missing from the word "note". The banner now accurately displays: "Please note that we will not be processing new applications at this time."
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->

## Screenshots
<img width="899" alt="image" src="https://github.com/user-attachments/assets/d9ecc11f-85e1-4987-8f63-b5e7fcf2b8e3" />

<!--- Attach screenshots or demo-gif of any UI changes -->

##  Checklist
- [ ] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [ ] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Related PRs
<!--- List any other related PRs --> 

## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 

## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
